### PR TITLE
Fixed instructions to create local .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Stop wasting time! 🏝🍹
 1. If you are using Linux, go to the next step. If you are using `Docker for Mac or Windows`, create a `.env` file 
 (I suggest you copy from [distribution version](env.dist) with `cp .env.dist .env`) and add
 `XDEBUG_REMOTE_HOST=host.docker.internal`). It is needed in order to allow Xdebug to connect back to the IDE in these OS.
-1. *(optional)* You can configure the XDebug in your editor/IDE in order to debug this application using it.
+1. *(optional)* You can configure the Xdebug in your editor/IDE in order to debug this application using it.
 [See the guide](docs/xdebug.md).
 1. That's all 😜.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Stop wasting time! 🏝🍹
 1. Clone this repository: `git clone git@github.com:xthiago/php-skeleton.git`
 1. Run `docker-compose run php composer install` to install the PHP dependencies.
 1. If you are using Linux, go to the next step. If you are using `Docker for Mac or Windows`, create a `.env` file 
-(I suggest you copy from [distribution version](env.dist) with `cp env.dist env.dist`) and add 
+(I suggest you copy from [distribution version](env.dist) with `cp .env.dist .env`) and add
 `XDEBUG_REMOTE_HOST=host.docker.internal`). It is needed in order to allow Xdebug to connect back to the IDE in these OS.
 1. *(optional)* You can configure the XDebug in your editor/IDE in order to debug this application using it.
 [See the guide](docs/xdebug.md).

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ A skeleton to start new high-quality PHP projects without worrying about bootstr
 
 The skeleton includes a PHP project properly configured with:
 
-- 🛠 **Docker and docker-compose** - because nobody wants (or should) to install project dependencies directly into their 
+- 🛠 **Docker and docker-compose** - because nobody wants (or should) to install project dependencies directly into their
 machines.
 - 🎉 **PHP 7.3**
 - 🕵 **Xdebug** - to stop wasting time printing values and start debugging PHP applications like a boss‍️.
-    - currently we provide [install instructions](docs/xdebug.md) for [PHPStorm](https://www.jetbrains.com/phpstorm/) - 
+    - currently we provide [install instructions](docs/xdebug.md) for [PHPStorm](https://www.jetbrains.com/phpstorm/) -
 but it also work with other editors/IDEs.
 - 🚦**PHPUnit** - to write and run unit tests and also generate code coverage.
 - 🏎 **PHP Parallel Lint** - to check syntax of PHP files.
 - 📋 **phpcs** - to ensure good coding standards.
     - currently check against [Doctrine standard](https://github.com/doctrine/coding-standard).
-- 👻 **phpstan** - to find errors in the code before running it. 
+- 👻 **phpstan** - to find errors in the code before running it.
 - 🚀 **Continuous Integration** - to ensure the previous tools runs for every contribution to your repository.
     - currently works out-of-box with [GitHub Actions](https://github.com/features/actions).
 
@@ -24,7 +24,7 @@ Stop wasting time! 🏝🍹
 ## Requirements
 
 - **Docker CE** - see the [install guide](https://docs.docker.com/install/).
-- **Docker Compose** - it is already included in *Docker Desktop for Mac* and *Windows*). If necessary, see the 
+- **Docker Compose** - it is already included in *Docker Desktop for Mac* and *Windows*). If necessary, see the
 [install guide](https://docs.docker.com/compose/install/).
 - **nektos/act** - (optional dependency) used to run [GitHub Actions](https://github.com/features/actions) locally. See
  the [install guide](https://github.com/nektos/act#installation).
@@ -34,7 +34,7 @@ Stop wasting time! 🏝🍹
 1. Make sure you have the requirements described above.
 1. Clone this repository: `git clone git@github.com:xthiago/php-skeleton.git`
 1. Run `docker-compose run php composer install` to install the PHP dependencies.
-1. If you are using Linux, go to the next step. If you are using `Docker for Mac or Windows`, create a `.env` file 
+1. If you are using Linux, go to the next step. If you are using `Docker for Mac or Windows`, create a `.env` file
 (I suggest you copy from [distribution version](env.dist) with `cp .env.dist .env`) and add
 `XDEBUG_REMOTE_HOST=host.docker.internal`). It is needed in order to allow Xdebug to connect back to the IDE in these OS.
 1. *(optional)* You can configure the Xdebug in your editor/IDE in order to debug this application using it.
@@ -46,12 +46,12 @@ Stop wasting time! 🏝🍹
 ### Web application
 
 In order to start the web application, you must create and start the PHP service:
- 
+
  ```
  docker-compose up -d
 ```
 
-Then you can open [https://localhost:8000](https://localhost:8000) in your browser. It will open 
+Then you can open [https://localhost:8000](https://localhost:8000) in your browser. It will open
 [web/index.php](web/index.php) file.
 
 For troubleshooting, you can watch the logs to see what's going on:
@@ -60,13 +60,13 @@ For troubleshooting, you can watch the logs to see what's going on:
 docker-compose logs -f
 ```
 
-See `docker-compose --help` to get more 
+See `docker-compose --help` to get more
 instructions.
 
 ### Command line
 
 You can access the terminal of PHP container with:
- 
+
  ```
 docker-compose exec php ash
 ```
@@ -75,7 +75,7 @@ You can also execute any command in PHP container from outside it typing and run
 
 ```
 docker-compose run php [command-name]
-# Example: docker-compose run php 
+# Example: docker-compose run php
 
 --help
 ```


### PR DESCRIPTION
This PR fixes the command used to create a local `.env` file by copying the one distributed with the project.

It also fixes a minor typo in *Xdebug* name and removes trailing whitespaces from the README file.